### PR TITLE
refactor: :recycle: removed init boot API call, changed publisherToken prop name  publisherToken renamed to checkoutToken and is now mandatory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [1.3.3](https://github.com/Appcharge/appcharge-checkout-react-sdk/compare/v1.3.2...v1.3.3) (2024-09-02)
+
 ### [1.3.2](https://github.com/Appcharge/appcharge-checkout-react-sdk/compare/v1.3.0...v1.3.2) (2024-07-21)
 
 ## [1.3.0](https://github.com/Appcharge/appcharge-checkout-react-sdk/compare/v1.2.0...v1.3.0) (2024-07-17)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [2.0.0](https://github.com/Appcharge/appcharge-checkout-react-sdk/compare/v1.3.4...v2.0.0) (2024-09-02)
+
+
+### ⚠ BREAKING CHANGES
+
+* publisherToken has been renamed to checkoutToken and is now a required field.
+
+* :recycle: changes ([2e907c0](https://github.com/Appcharge/appcharge-checkout-react-sdk/commit/2e907c016394868d405ebab082fd618642ce70f8))
+
 ### [1.3.4](https://github.com/Appcharge/appcharge-checkout-react-sdk/compare/v1.3.3...v1.3.4) (2024-09-02)
 
 ### [1.3.3](https://github.com/Appcharge/appcharge-checkout-react-sdk/compare/v1.3.2...v1.3.3) (2024-09-02)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [1.3.4](https://github.com/Appcharge/appcharge-checkout-react-sdk/compare/v1.3.3...v1.3.4) (2024-09-02)
+
 ### [1.3.3](https://github.com/Appcharge/appcharge-checkout-react-sdk/compare/v1.3.2...v1.3.3) (2024-09-02)
 
 ### [1.3.2](https://github.com/Appcharge/appcharge-checkout-react-sdk/compare/v1.3.0...v1.3.2) (2024-07-21)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "appcharge-checkout-reactjs-sdk",
-  "version": "1.3.4",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "appcharge-checkout-reactjs-sdk",
-      "version": "1.3.4",
+      "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
         "@rollup/plugin-replace": "^5.0.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "appcharge-checkout-reactjs-sdk",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "appcharge-checkout-reactjs-sdk",
-      "version": "1.3.2",
+      "version": "1.3.3",
       "license": "MIT",
       "dependencies": {
         "@rollup/plugin-replace": "^5.0.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "appcharge-checkout-reactjs-sdk",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "appcharge-checkout-reactjs-sdk",
-      "version": "1.3.3",
+      "version": "1.3.4",
       "license": "MIT",
       "dependencies": {
         "@rollup/plugin-replace": "^5.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appcharge-checkout-reactjs-sdk",
-  "version": "1.3.4",
+  "version": "2.0.0",
   "author": "Appcharge inc",
   "license": "MIT",
   "main": "lib/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appcharge-checkout-reactjs-sdk",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "author": "Appcharge inc",
   "license": "MIT",
   "main": "lib/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appcharge-checkout-reactjs-sdk",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "author": "Appcharge inc",
   "license": "MIT",
   "main": "lib/index.js",

--- a/src/components/ui/AppchargeCheckout/index.tsx
+++ b/src/components/ui/AppchargeCheckout/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useEffect } from 'react';
 import './styles.scss';
 
 export interface Product {
@@ -229,7 +229,7 @@ export interface AppchargeCheckoutProps {
   sessionToken: string;
   referrerUrl: string;
   sourceVersion?: string;
-  publisherToken?: string;
+  checkoutToken: string;
   locale?: AppchargeLocale;
   playerId?: string;
   onOpen?: () => void;
@@ -247,7 +247,7 @@ function AppchargeCheckout({
   playerId,
   sessionToken,
   sourceVersion,
-  publisherToken = '',
+  checkoutToken,
   locale = 'en',
   onClose,
   onOpen,
@@ -258,11 +258,6 @@ function AppchargeCheckout({
   onOrderCompletedFailed,
   onOrderCompletedSuccessfully,
 }: AppchargeCheckoutProps) {
-  const iframeRef = useRef<HTMLIFrameElement>(null);
-
-  const sendIframeMessage = (iframe: HTMLIFrameElement, message: FEMessage) => {
-    iframe.contentWindow?.postMessage(message, checkoutUrl);
-  };
 
   useEffect(() => {
     const eventHandler = (massageEvent: MessageEvent<FEMessage>) => {
@@ -307,12 +302,16 @@ function AppchargeCheckout({
     onOrderCompletedSuccessfully,
   ]);
 
+  if (!checkoutToken) {
+    throw Error('checkoutToken prop is missing in AppchargeCheckout component');
+  } 
+
   const sdkVersion = 'process.env.sdkVersion';
   const queryParams = `sdk-version=react-${sdkVersion}&source-version=${
     sourceVersion || ''
-  }&publisher-token=${publisherToken}${locale ? `&locale=${locale}` : ''}${playerId ? `&player_id=${playerId}` : ''}`;
+  }&checkout-token=${checkoutToken}${locale ? `&locale=${locale}` : ''}${playerId ? `&player_id=${playerId}` : ''}`;
 
-  const url = `${checkoutUrl}/${sessionToken}?${queryParams}`; // https://checkout-v2.appcharge.com
+  const url = `${checkoutUrl}/${sessionToken}?${queryParams}`;
 
   return (
     <iframe
@@ -320,17 +319,7 @@ function AppchargeCheckout({
       className="iframe"
       title="checkout"
       allow="payment *"
-      ref={iframeRef}
-      onLoad={() => {
-        iframeRef.current &&
-          sendIframeMessage(iframeRef.current, {
-            event: EFEEvent.APPCHARGE_THEME,
-            params:
-              localStorage.getItem('ac_co_theme') &&
-              JSON.parse(localStorage.getItem('ac_co_theme') || 'null'),
-          });
-        onInitialLoad?.();
-      }}
+      onLoad={() => onInitialLoad?.()}
     ></iframe>
   );
 }

--- a/src/components/ui/AppchargeCheckoutInit/index.tsx
+++ b/src/components/ui/AppchargeCheckoutInit/index.tsx
@@ -9,11 +9,11 @@ export interface AppchargeCheckoutInitProps {
 
 function AppchargeCheckoutInit({
   environment = 'sandbox',
-  domain = window.location.host,
   checkoutToken,
+  domain = window.location.host,
 }: AppchargeCheckoutInitProps) {
-  
   const env = environment === 'prod' ? '' : `-${environment}`;
+  
   if (!checkoutToken) {
       throw Error('checkoutToken prop is missing in AppchargeCheckoutInit component')
   }

--- a/src/components/ui/AppchargeCheckoutInit/index.tsx
+++ b/src/components/ui/AppchargeCheckoutInit/index.tsx
@@ -12,8 +12,8 @@ function AppchargeCheckoutInit({
   domain = window.location.host,
   checkoutToken,
 }: AppchargeCheckoutInitProps) {
+  
   const env = environment === 'prod' ? '' : `-${environment}`;
-
   if (!checkoutToken) {
       throw Error('checkoutToken prop is missing in AppchargeCheckoutInit component')
   }

--- a/src/components/ui/AppchargeCheckoutInit/index.tsx
+++ b/src/components/ui/AppchargeCheckoutInit/index.tsx
@@ -1,43 +1,26 @@
-import { useEffect } from 'react';
 import './styles.scss';
 
 export interface AppchargeCheckoutInitProps {
   sandbox?: boolean;
   domain?: string;
-  publisherToken?: string;
+  checkoutToken: string;
   environment?: 'dev' | 'sandbox' | 'prod';
 }
-
-const APPCHARGE_CHECKOUT_THEME = 'ac_co_theme';
 
 function AppchargeCheckoutInit({
   environment = 'sandbox',
   domain = window.location.host,
-  publisherToken = '',
+  checkoutToken,
 }: AppchargeCheckoutInitProps) {
   const env = environment === 'prod' ? '' : `-${environment}`;
 
-  useEffect(() => {
-    fetch(`https://api${env}.appcharge.com/checkout/v1/${domain}/boot`, {
-      headers: {
-        'x-checkout-token': publisherToken,
-      },
-    })
-      .then((res) => res.json())
-      .then((data) => {
-        localStorage.setItem(
-          APPCHARGE_CHECKOUT_THEME,
-          JSON.stringify({ theme: data.theme, pks: data.pks })
-        );
-      })
-      .catch((err) => {
-        localStorage.removeItem(APPCHARGE_CHECKOUT_THEME);
-      });
-  }, [domain, env, publisherToken]);
+  if (!checkoutToken) {
+      throw Error('checkoutToken prop is missing in AppchargeCheckoutInit component')
+  }
 
   return (
     <iframe
-      src={`https://checkout-v2${env}.appcharge.com/handshake`}
+      src={`https://checkout-v2${env}.appcharge.com/handshake?checkout-token=${checkoutToken}`}
       className="iframe-transparent"
       title="checkout-transparent"
     ></iframe>


### PR DESCRIPTION
…n prop name

publisherToken renamed to checkoutToken and is now mandatory