### PR TITLE
refactor!: :recycle: remove boot init call, change publisherToken prop name

### DIFF
--- a/src/components/ui/AppchargeCheckout/index.tsx
+++ b/src/components/ui/AppchargeCheckout/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useEffect } from 'react';
 import './styles.scss';
 
 export interface Product {
@@ -229,7 +229,7 @@ export interface AppchargeCheckoutProps {
   sessionToken: string;
   referrerUrl: string;
   sourceVersion?: string;
-  publisherToken?: string;
+  checkoutToken: string;
   locale?: AppchargeLocale;
   playerId?: string;
   onOpen?: () => void;
@@ -247,7 +247,7 @@ function AppchargeCheckout({
   playerId,
   sessionToken,
   sourceVersion,
-  publisherToken = '',
+  checkoutToken,
   locale = 'en',
   onClose,
   onOpen,
@@ -258,11 +258,6 @@ function AppchargeCheckout({
   onOrderCompletedFailed,
   onOrderCompletedSuccessfully,
 }: AppchargeCheckoutProps) {
-  const iframeRef = useRef<HTMLIFrameElement>(null);
-
-  const sendIframeMessage = (iframe: HTMLIFrameElement, message: FEMessage) => {
-    iframe.contentWindow?.postMessage(message, checkoutUrl);
-  };
 
   useEffect(() => {
     const eventHandler = (massageEvent: MessageEvent<FEMessage>) => {
@@ -307,12 +302,16 @@ function AppchargeCheckout({
     onOrderCompletedSuccessfully,
   ]);
 
+  if (!checkoutToken) {
+    throw Error('checkoutToken prop is missing in AppchargeCheckout component');
+  } 
+
   const sdkVersion = 'process.env.sdkVersion';
   const queryParams = `sdk-version=react-${sdkVersion}&source-version=${
     sourceVersion || ''
-  }&publisher-token=${publisherToken}${locale ? `&locale=${locale}` : ''}${playerId ? `&player_id=${playerId}` : ''}`;
+  }&checkout-token=${checkoutToken}${locale ? `&locale=${locale}` : ''}${playerId ? `&player_id=${playerId}` : ''}`;
 
-  const url = `${checkoutUrl}/${sessionToken}?${queryParams}`; // https://checkout-v2.appcharge.com
+  const url = `${checkoutUrl}/${sessionToken}?${queryParams}`;
 
   return (
     <iframe
@@ -320,17 +319,7 @@ function AppchargeCheckout({
       className="iframe"
       title="checkout"
       allow="payment *"
-      ref={iframeRef}
-      onLoad={() => {
-        iframeRef.current &&
-          sendIframeMessage(iframeRef.current, {
-            event: EFEEvent.APPCHARGE_THEME,
-            params:
-              localStorage.getItem('ac_co_theme') &&
-              JSON.parse(localStorage.getItem('ac_co_theme') || 'null'),
-          });
-        onInitialLoad?.();
-      }}
+      onLoad={() => onInitialLoad?.()}
     ></iframe>
   );
 }

--- a/src/components/ui/AppchargeCheckoutInit/index.tsx
+++ b/src/components/ui/AppchargeCheckoutInit/index.tsx
@@ -1,43 +1,26 @@
-import { useEffect } from 'react';
 import './styles.scss';
 
 export interface AppchargeCheckoutInitProps {
   sandbox?: boolean;
   domain?: string;
-  publisherToken?: string;
+  checkoutToken: string;
   environment?: 'dev' | 'sandbox' | 'prod';
 }
-
-const APPCHARGE_CHECKOUT_THEME = 'ac_co_theme';
 
 function AppchargeCheckoutInit({
   environment = 'sandbox',
   domain = window.location.host,
-  publisherToken = '',
+  checkoutToken,
 }: AppchargeCheckoutInitProps) {
   const env = environment === 'prod' ? '' : `-${environment}`;
 
-  useEffect(() => {
-    fetch(`https://api${env}.appcharge.com/checkout/v1/${domain}/boot`, {
-      headers: {
-        'x-checkout-token': publisherToken,
-      },
-    })
-      .then((res) => res.json())
-      .then((data) => {
-        localStorage.setItem(
-          APPCHARGE_CHECKOUT_THEME,
-          JSON.stringify({ theme: data.theme, pks: data.pks })
-        );
-      })
-      .catch((err) => {
-        localStorage.removeItem(APPCHARGE_CHECKOUT_THEME);
-      });
-  }, [domain, env, publisherToken]);
+  if (!checkoutToken) {
+      throw Error('checkoutToken prop is missing in AppchargeCheckoutInit component')
+  }
 
   return (
     <iframe
-      src={`https://checkout-v2${env}.appcharge.com/handshake`}
+      src={`https://checkout-v2${env}.appcharge.com/handshake?checkout-token=${checkoutToken}`}
       className="iframe-transparent"
       title="checkout-transparent"
     ></iframe>


### PR DESCRIPTION
BREAKING CHANGE: publisherToken prop renamed to checkoutToken and is now mandatory