### PR TITLE
release: 4.3.0 — fix iframe full-screen styling dropped by tree-shaking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [4.3.0](https://github.com/Appcharge/appcharge-checkout-react-sdk/compare/v4.2.0...v4.3.0) (2026-06-05)
+
+
+### Bug Fixes
+
+* restore iframe full-screen styling dropped by tree-shaking ([d59a085](https://github.com/Appcharge/appcharge-checkout-react-sdk/commit/d59a0858415a062d098461673f4667927926c6e6))
+
 ## [4.2.0](https://github.com/Appcharge/appcharge-checkout-react-sdk/compare/v4.1.1...v4.2.0) (2026-05-26)
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "appcharge-checkout-reactjs-sdk",
-  "version": "4.2.0",
+  "version": "4.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "appcharge-checkout-reactjs-sdk",
-      "version": "4.2.0",
+      "version": "4.3.0",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.6.1"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
   "types": "lib/index.d.ts",
   "sideEffects": [
     "lib/index.js",
-    "lib/index.esm.js"
+    "lib/index.esm.js",
+    "*.scss",
+    "*.css"
   ],
   "files": [
     "src",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appcharge-checkout-reactjs-sdk",
-  "version": "4.2.0",
+  "version": "4.3.0",
   "author": "Appcharge inc",
   "license": "MIT",
   "main": "lib/index.js",


### PR DESCRIPTION
## Summary
- Fixes the checkout iframe opening tiny (~300×150) in 4.2.0. Root cause: the `sideEffects` allowlist added in 4.2.0 only listed the compiled `lib` entry files, so Rollup treated all `src/**` modules — including `import './styles.scss'` — as side-effect-free and **tree-shook the style injection out of the build**. The published `lib` lost `styleInject(.iframe{…})`, so the iframe fell back to the HTML default size.
- Adds `*.scss` / `*.css` to `sideEffects` so style imports are never dropped, while JS tree-shaking still applies.
- **No impact on the 4.2.0 performance work** — `warmupCheckout` / `preconnectCheckout` remain intact and exported.

## Root cause detail
| Change (4.0.0 → 4.2.0) | Regression? |
|---|---|
| `sideEffects: ["lib/index.js","lib/index.esm.js"]` added | **YES** — dropped `styleInject` → iframe 300×150 |
| `utils/preconnect.ts` + warmup/preconnect | No (intended perf) |
| `onPaymentIntent` / `ON_PAYMENT_INTENT` | No (additive optional callback) |
| `AppchargeCheckoutInit` export removed | Breaking only if consumed directly (superseded by `warmupCheckout`) |
| peerDep/devDep cleanup, security `overrides` | No |

## Verification
Built the branch locally:
- `grep -c styleInject lib/index.js` → `2` (was `0` on 4.2.0)
- Injected rule byte-identical to 4.0.0: `.iframe { height:100vh; height:100dvh; width:100%; border:0; position:absolute; top:0; left:0; z-index:9999; }`
- `warmupCheckout`, `preconnectCheckout`, `getPricePoints`, `AppchargeCheckout` all still exported.

## Test plan
- [ ] `yarn build` and confirm `lib/index.js` contains `styleInject(css_248z)`
- [ ] Mount `<AppchargeCheckout />` in a consumer app and confirm the iframe renders full-screen
- [ ] Confirm checkout warmup/preconnect still fire on import

Made with [Cursor](https://cursor.com)