### PR TITLE
feat: support React 17 alongside React 18

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "postversion": "git push --tags && yarn publish . --tag $npm_package_version && git push && echo \"Successfully released version $npm_package_version!\""
   },
   "peerDependencies": {
-    "react": "^18.0.2"
+    "react": "^17.0.0 || ^18.0.0"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^20.0.0",


### PR DESCRIPTION
## Summary
- Widen the `react` peerDependency from `^18.0.2` to `^17.0.0 || ^18.0.0` so the SDK can be consumed by React 17 apps.
- No bundle/code changes — peer range only. The SDK uses no React-18-only APIs (only `useEffect` and the automatic JSX runtime `react/jsx-runtime`, available since React 17.0.0). The performance code (warmupCheckout / preconnectCheckout / auto-preconnect on import) is pure DOM and React-agnostic.

## Test plan
- [x] Install and server-render against `react@17.0.2`: no peer conflicts, all exports present, iframe renders with the `.iframe` class.
- [ ] Verify React 18 consumers remain unaffected (peer range only).

Made with [Cursor](https://cursor.com)