### PR TITLE
fix: cover host page behind iOS 26 Safari toolbar (Liquid Glass)

### DIFF
--- a/src/components/ui/AppchargeCheckout/styles.scss
+++ b/src/components/ui/AppchargeCheckout/styles.scss
@@ -8,3 +8,14 @@
   left: 0;
   z-index: 9999;
 }
+
+/* iOS 26 Safari "Liquid Glass" only (class added by enableLiquidGlassFix on
+   iOS/iPadOS 26+). Stretch the iframe to the FULL screen — including behind the
+   translucent bottom toolbar — so the publisher's page no longer shows through
+   there. `100lvh` is the large viewport (chrome retracted) = full screen height;
+   `position: fixed` anchors it to the viewport regardless of ancestors. Scoped to
+   the marker class, so there is zero effect on Android / desktop / older iOS. */
+html.ac-ios26-liquid-glass .iframe {
+  position: fixed;
+  height: 100lvh;
+}

--- a/src/utils/liquid-glass.test.ts
+++ b/src/utils/liquid-glass.test.ts
@@ -5,6 +5,7 @@ import {
   ensureViewportFitCover,
   enableLiquidGlassFix,
   isIos26OrAbove,
+  LIQUID_GLASS_CLASS,
 } from './liquid-glass';
 
 function viewportMetas(): HTMLMetaElement[] {
@@ -47,6 +48,7 @@ const UA = {
 
 beforeEach(() => {
   document.head.innerHTML = '';
+  document.documentElement.classList.remove(LIQUID_GLASS_CLASS);
 });
 
 describe('isIos26OrAbove', () => {
@@ -77,21 +79,24 @@ describe('isIos26OrAbove', () => {
 });
 
 describe('enableLiquidGlassFix', () => {
-  it('injects viewport-fit=cover on iOS 26 and reverts on cleanup', () => {
+  it('injects viewport-fit=cover + marks <html> on iOS 26 and reverts on cleanup', () => {
     mockNavigator({ userAgent: UA.iphone26 });
 
     const restore = enableLiquidGlassFix();
     expect(viewportMetas()).toHaveLength(1);
     expect(viewportMetas()[0].getAttribute('content')).toContain('viewport-fit=cover');
+    expect(document.documentElement.classList.contains(LIQUID_GLASS_CLASS)).toBe(true);
 
     restore();
     expect(viewportMetas()).toHaveLength(0);
+    expect(document.documentElement.classList.contains(LIQUID_GLASS_CLASS)).toBe(false);
   });
 
   it('is a hard no-op on iOS < 26', () => {
     mockNavigator({ userAgent: UA.iphone18 });
     const restore = enableLiquidGlassFix();
     expect(viewportMetas()).toHaveLength(0);
+    expect(document.documentElement.classList.contains(LIQUID_GLASS_CLASS)).toBe(false);
     restore();
     expect(viewportMetas()).toHaveLength(0);
   });
@@ -100,6 +105,7 @@ describe('enableLiquidGlassFix', () => {
     mockNavigator({ userAgent: UA.androidChrome });
     enableLiquidGlassFix();
     expect(viewportMetas()).toHaveLength(0);
+    expect(document.documentElement.classList.contains(LIQUID_GLASS_CLASS)).toBe(false);
   });
 });
 

--- a/src/utils/liquid-glass.ts
+++ b/src/utils/liquid-glass.ts
@@ -20,6 +20,14 @@
 const NOOP = (): void => { /* nothing to restore */ };
 
 /**
+ * Marker class added to <html> on iOS/iPadOS 26+ only. CSS scoped to this class
+ * (see styles.scss) stretches the checkout iframe to the full screen so it covers
+ * the area behind the translucent toolbar (otherwise the publisher's page shows
+ * through there). Kept in sync with styles.scss.
+ */
+export const LIQUID_GLASS_CLASS = 'ac-ios26-liquid-glass';
+
+/**
  * True only on iOS / iPadOS 26 or newer. Covers classic iPhone/iPod/iPad user
  * agents ("... OS 26_0 ...") and iPadOS masquerading as macOS ("MacIntel" +
  * touch), where the Safari version ("Version/26") tracks the OS version.
@@ -88,14 +96,38 @@ export function ensureViewportFitCover(): () => void {
 }
 
 /**
- * Apply the iOS 26 Safari Liquid Glass fix — but ONLY on iOS/iPadOS 26+. Returns a
- * cleanup function that reverts every change (a no-op on unaffected platforms), so
- * the publisher page is left exactly as it was once the checkout unmounts.
+ * Add the iOS-26 marker class to <html> (see LIQUID_GLASS_CLASS). Returns a
+ * function that removes it again. No-op / never-throws off the happy path.
+ */
+function markLiquidGlassRoot(): () => void {
+  try {
+    const html = typeof document !== 'undefined' ? document.documentElement : null;
+    if (!html || html.classList.contains(LIQUID_GLASS_CLASS)) return NOOP;
+    html.classList.add(LIQUID_GLASS_CLASS);
+    return () => { try { html.classList.remove(LIQUID_GLASS_CLASS); } catch { /* noop */ } };
+  } catch {
+    return NOOP;
+  }
+}
+
+/**
+ * Apply the iOS 26 Safari Liquid Glass fix — but ONLY on iOS/iPadOS 26+. It:
+ *   1. opts the host page into `viewport-fit=cover`, and
+ *   2. marks <html> so the iframe is stretched full-screen (CSS in styles.scss),
+ *      covering the publisher's page behind the translucent toolbar.
+ * Returns a cleanup function that reverts every change (a no-op on unaffected
+ * platforms), so the publisher page is left exactly as it was once checkout
+ * unmounts.
  *
  * @example
  * useEffect(() => enableLiquidGlassFix(), []);
  */
 export function enableLiquidGlassFix(): () => void {
   if (!isIos26OrAbove()) return NOOP;
-  return ensureViewportFitCover();
+  const restoreViewport = ensureViewportFitCover();
+  const restoreClass = markLiquidGlassRoot();
+  return () => {
+    restoreClass();
+    restoreViewport();
+  };
 }


### PR DESCRIPTION
## Summary

Follow-up to #30 (already merged into `develop`). #30 added the iOS-26-gated `viewport-fit=cover` injection, which is necessary but **not sufficient**: on real iOS/iPadOS 26 Safari, opting into `viewport-fit=cover` lets the **publisher's store page** (balloons, "MORE" ribbon, etc.) show through *behind* Safari's translucent bottom toolbar instead of the white band. See the reported screenshot.

This PR closes that gap by making the checkout iframe fully cover the area behind the toolbar — **only on iOS/iPadOS 26+**:

- `enableLiquidGlassFix()` now also adds a marker class `ac-ios26-liquid-glass` to `<html>` (in addition to the existing `viewport-fit=cover` injection), and removes it on cleanup.
- Scoped CSS `html.ac-ios26-liquid-glass .iframe { position: fixed; height: 100lvh; }` stretches the iframe to the full screen height (`100lvh` = large viewport / chrome retracted) so it paints behind the translucent toolbar.

### Why this is safe (no regression)
- The class is added **only** when `isIos26OrAbove()` is true. The base `.iframe` rule (`position: absolute; height: 100dvh`) is completely unchanged, so Android / desktop / iOS < 26 / non-notched devices are byte-for-byte identical to today.
- The CSS override is scoped to the marker class, which never appears off iOS 26+.
- Everything is reverted on unmount (class + viewport meta), leaving the publisher page pristine.
- Verified the scoped rule survives Rollup tree-shaking into both `lib/index.js` and `lib/index.esm.js` (guards against the regression fixed in #28).

## Changes
- `src/utils/liquid-glass.ts` — export `LIQUID_GLASS_CLASS`, add `markLiquidGlassRoot()`, wire it into `enableLiquidGlassFix()` cleanup.
- `src/components/ui/AppchargeCheckout/styles.scss` — add the iOS-26-scoped full-screen iframe rule.
- `src/utils/liquid-glass.test.ts` — assert the `<html>` class is added on iOS 26 and is a no-op / cleaned up elsewhere.

## Test plan
- [x] `jest src/utils/liquid-glass.test.ts` — 13/13 pass
- [x] `npm run build` — compiles; scoped rule present in built CJS + ESM
- [ ] Real iOS 26 Safari device: confirm no white band **and** no store content visible behind the translucent toolbar; toolbar expanded + collapsed; bottom CTA not obscured
- [ ] Android Chrome / iOS < 26 / desktop: no visual change

Made with [Cursor](https://cursor.com)